### PR TITLE
Fixed formatting of Commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,9 @@ Example command Line script to set up your hash and hubot philips app
 ## Commands:
 -   hubot hue lights - list all lights
 -   hubot hue light {light number}  - shows light status
--   hubot hue hsb light {light number} {hue} {saturation} {brightness} 
-    - hue range: 0-6553
-    - saturation range: 0-254
-    - brightness range: 0-254
--   hubot hue xy light {light number} {x} {y} 
-    - x-y values are in the [CIE Color Space](http://developers.meethue.com/coreconcepts.html#color_gets_more_complicated)
-    - valid x: 0.0-1.0
-    - valid y: 0.0-1.0
--   hubot hue ct light {light number} {color temp}
-    - color temperature values use [Mired color temperature](http://en.wikipedia.org/wiki/Mired) 
-    - color temperature range: 153-500 (153 appears 6500K, 500 appears 2000K)
+-   hubot hue hsb light {light number} {hue 0-6553} {saturation 0-254} {brightness 0-254} 
+-   hubot hue xy light {light number} {x 0.0-1.0} {y 0.0-1.0} 
+-   hubot hue ct light {light number} {color temp 153-500}
 -   hubot hue turn light {light number} {on|off} - flips the switch
 -   hubot hue groups - groups lights together to control with one API call
 -   hubot hue config - reads bridge config
@@ -83,6 +75,10 @@ Example command Line script to set up your hash and hubot philips app
 
 
 ## Notes:
+
+- x-y values are in the [CIE Color Space](http://developers.meethue.com/coreconcepts.html#color_gets_more_complicated)
+- color temperature values use [Mired color temperature](http://en.wikipedia.org/wiki/Mired) 
+- color temperature range: 153-500 (153 appears 6500K, 500 appears 2000K)
 
 ## Author:
    kingbin - chris.blazek@gmail.com


### PR DESCRIPTION
Hubot help wants a specific format for this section, so sub-items aren't supported. Merged the sub-item info into the descriptions themselves and notes into the Notes section.
