### PR TITLE
Fix hue-sat-bri typo for hue range

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Example command Line script to set up your hash and hubot philips app
 -   hubot hue lights - list all lights
 -   hubot hue light {light number}  - shows light status
 -   hubot hue hsb light {light number} {hue} {saturation} {brightness} 
-    - hue range: 0-6553
+    - hue range: 0-65535
     - saturation range: 0-254
     - brightness range: 0-254
 -   hubot hue xy light {light number} {x} {y} 

--- a/src/philips-hue.coffee
+++ b/src/philips-hue.coffee
@@ -36,7 +36,7 @@
 #   hubot hue set config (name|linkbutton) <value>- change the name or programatically press the link button
 #   hubot hue (alert|alerts) light <light number> - blink once or blink for 10 seconds specific light
 #   hubot hue hsb light <light number> <hue> <saturation> <brightness>
-#   - hue range: 0-6553
+#   - hue range: 0-65535
 #   - saturation range: 0-254
 #   - brightness range: 0-254
 #   hubot hue xy light <light number> <x> <y>


### PR DESCRIPTION
I had a typo in the range.  According to the docs, the range is 0-65535, which is a number that makes an order of magnitude more sense than 6553. 
