### PR TITLE
Refactor to use `node-hue-api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d
 -   hubot hue groups - groups lights together to control with one API call
 -   hubot hue config - reads bridge config
 -   hubot hue hash - get a hash code (press the link button)
--   hubot hue inkbutton - programatically press the link button
+-   hubot hue linkbutton - programatically press the link button
 -   hubot hue {alert|alerts} light {light number} - blink once or blink for 10 seconds specific light
 -   hubot hue group {group name}=[{comma separated list of light indexes}]
 -   hubot hue ls groups - lists the groups of lights

--- a/README.md
+++ b/README.md
@@ -5,39 +5,50 @@ This is a hubot plugin that will control your philips hue lights
 [![Build Status](https://travis-ci.org/hubot-scripts/hubot-example.png)](https://travis-ci.org/kingbin/hubot-philipshue)
 
 ## Dependencies:
--   [A Local Hubot Installation](https://github.com/github/hubot/blob/master/docs/README.md "A Local Hubot Installation")
--   [Philips Hue Lightbulb system](https://www.meethue.com/en-US "Philips Hue Lightbulb system")
+- [A Local Hubot Installation](https://github.com/github/hubot/blob/master/docs/README.md "A Local Hubot Installation")
+- [Philips Hue Lightbulb system](https://www.meethue.com/en-US "Philips Hue Lightbulb system")
 -	I'm using [campfire](https://campfirenow.com/ "campfire") to interact with my system.
+
+Uses the [`node-hue-api`](https://github.com/peter-murray/node-hue-api "Node Hue API") NPM package to communicate with the hue bridge.
 
 ## Installation
 
 ###The Quick Installation
 Run the following command to make sure the module is installed to your local Hubot instance.
 
-    $ npm install hubot-philipshue --save
+```bash
+$ npm install hubot-philipshue --save
+```
 
 ###Manual Installation
 Run the following command to install the module in your hubot project.
 
-    $ npm install hubot-philipshue
+```bash
+$ npm install hubot-philipshue
+```
 
 Add the package `hubot-philipshue` as a dependency in your Hubot `package.json` file.
 
+```
     "dependencies": {
       "hubot-philipshue": "*"
     }
+```
+
 ###And then turn the Hubot script on
 To enable the script, add the `hubot-philipshue` entry to the `external-scripts.json` file (you may need to create this file).
 
-    ["hubot-philipshue"]
-
+```
+["hubot-philipshue"]
+```
 
 ## Configuration:
 ####Environment variables:
 
-   PHILIPS\_HUE\_HASH : export PHILIPS\_HUE\_HASH="secrets"
-
-   PHILIPS\_HUE\_IP : export PHILIPS\_HUE\_IP="xxx.xxx.xxx.xxx"
+```
+export PHILIPS_HUE_HASH="secrets"
+export PHILIPS_HUE_IP="xxx.xxx.xxx.xxx"
+```
 
 ####Getting your Hue Hash
 
@@ -45,20 +56,29 @@ To enable the script, add the `hubot-philipshue` entry to the `external-scripts.
 
  Make an HTTP POST request of the following to http://YourHueHub/api
 
-	{"username": "YourHash", "devicetype": "YourAppName"}
+```
+{"username": "YourHash", "devicetype": "YourAppName"}
+```
  
 If you have not pressed the button on the Hue Hub you will receive an error like this;
 
-	{"error":{"type":101,"address":"/","description":"link button not pressed"}}
- Press the link button on the hub and try again and you should receive;
+```json
+{"error":{"type":101,"address":"/","description":"link button not pressed"}}
+```
 
-	{"success":{"username":"YourHash"}}
- The key above will be the username you sent, remember this, you'll need it in all future requests
+Press the link button on the hub and try again and you should receive;
 
-Example command Line script to set up your hash and hubot philips app
+```json
+{"success":{"username":"YourHash"}}
+```
 
-	curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d '{"username": "YourHash", "devicetype": "YourAppName"}'
+The key above will be the username you sent, remember this, you'll need it in all future requests
 
+Example command Line script to set up your hash and Hubot Philips app:
+
+```bash
+$ curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d '{"username": "YourHash", "devicetype": "YourAppName"}'
+```
 
 ## Commands:
 -   hubot hue lights - list all lights
@@ -78,7 +98,7 @@ Example command Line script to set up your hash and hubot philips app
 -   hubot hue groups - groups lights together to control with one API call
 -   hubot hue config - reads bridge config
 -   hubot hue hash - get a hash code (press the link button)
--   hubot hue set config {name|linkbutton} {value\}- change the name or programatically press the link button
+-   hubot hue inkbutton - programatically press the link button
 -   hubot hue {alert|alerts} light {light number} - blink once or blink for 10 seconds specific light
 -   hubot hue group {group name}=[{comma separated list of light indexes}]
 -   hubot hue ls groups - lists the groups of lights

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install hubot-philipshue
 
 Add the package `hubot-philipshue` as a dependency in your Hubot `package.json` file.
 
-```
+```json
     "dependencies": {
       "hubot-philipshue": "*"
     }
@@ -38,14 +38,14 @@ Add the package `hubot-philipshue` as a dependency in your Hubot `package.json` 
 ###And then turn the Hubot script on
 To enable the script, add the `hubot-philipshue` entry to the `external-scripts.json` file (you may need to create this file).
 
-```
+```json
 ["hubot-philipshue"]
 ```
 
 ## Configuration:
 ####Environment variables:
 
-```
+```bash
 export PHILIPS_HUE_HASH="secrets"
 export PHILIPS_HUE_IP="xxx.xxx.xxx.xxx"
 ```
@@ -56,7 +56,7 @@ export PHILIPS_HUE_IP="xxx.xxx.xxx.xxx"
 
  Make an HTTP POST request of the following to http://YourHueHub/api
 
-```
+```json
 {"username": "YourHash", "devicetype": "YourAppName"}
 ```
  

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/kingbin/hubot-philipshue/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.6"
+    "coffee-script": "~1.6",
+    "node-hue-api": "^1.0.5"
   },
   "devDependencies": {
     "mocha": "~1.14.0",

--- a/src/philips-hue.coffee
+++ b/src/philips-hue.coffee
@@ -25,6 +25,8 @@
 #
 # ie: curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d '{"username": "YourHash", "devicetype": "YourAppName"}'
 #
+# Dependencies:
+#   "node-hue-api": "^1.0.5"
 #
 # Commands:
 #   hubot hue lights - list all lights
@@ -33,7 +35,7 @@
 #   hubot hue groups - groups lights together to control with one API call
 #   hubot hue config - reads bridge config
 #   hubot hue hash - get a hash code (press the link button)
-#   hubot hue set config (name|linkbutton) <value>- change the name or programatically press the link button
+#   hubot hue linkbutton - programatically press the link button
 #   hubot hue (alert|alerts) light <light number> - blink once or blink for 10 seconds specific light
 #   hubot hue hsb light <light number> <hue 0-65535> <saturation 0-254> <brightness 0-254>
 #   hubot hue xy light <light number> <x 0.0-1.0> <y 0.0-1.0>
@@ -52,144 +54,158 @@
 # Author:
 #   kingbin - chris.blazek@gmail.com
 
+hue = require("node-hue-api")
+HueApi = hue.HueApi
+lightState = hue.lightState
 
 module.exports = (robot) ->
   base_url = process.env.PHILIPS_HUE_IP
   hash  = process.env.PHILIPS_HUE_HASH
+  api = new HueApi(base_url, hash)
+  state = lightState.create();
 
+  # GROUP COMMANDS
+  robot.respond /hue (?:ls )?groups/i, (msg) ->
+    api.groups (err, groups) ->
+      return handleError msg, err if err
+      robot.logger.debug groups
+      msg.send "Light groups:"
+      for group in groups
+        if group.id == '0'
+          msg.send "- #{group.id}: '#{group.name}' (All)"
+        else
+          msg.send "- #{group.id}: '#{group.name}' (#{group.lights.join(', ')})"
 
-# If you have more than the initial 3 lights, add them to the 'all' array below
-  fake_groups =
-    1: [1]
-    2: [2]
-    3: [3]
-    all: [1,2,3]
-
-# GROUP COMMANDS
-  robot.respond /hue groups/i, (msg) ->
-    url = "http://#{base_url}/api/#{hash}/groups"
-    getGenInfo msg, url, (responseText) ->
-      msg.send "Groups: " + responseText
-
-# FAKE GROUP COMMANDS
   robot.respond /hue group (\w+)=(\[((\d)+,)*((\d)+)\])/i, (msg) ->
-    msg.send "setting " + msg.match[1] + "=" +msg.match[2]
-    fake_groups[msg.match[1]] = JSON.parse(msg.match[2])
+    group_name = msg.match[1]
+    group_lights = JSON.parse(msg.match[2])
+    msg.send "Setting #{group_name} to #{group_lights.join(', ')}"
+    api.createGroup group_name, group_lights, (err, response) ->
+      return handleError msg, err if err
+      robot.logger.debug response
+      msg.send "Group created!"
 
-  robot.respond /hue rm group (\w+)/i, (msg) ->
-    msg.send "removing " + msg.match[1]
-    delete fake_groups[msg.match[1]]
+  robot.respond /hue rm group (\d)/i, (msg) ->
+    group_id = msg.match[1]
+    msg.send "Deleting #{group_id}"
+    api.deleteGroup group_id, (err, response) ->
+      return handleError msg, err if err
+      robot.logger.debug response
+      msg.send "Group deleted!"
 
-  robot.respond /hue ls groups/i, (msg) ->
-    for key of fake_groups
-      msg.send key + " = [" + fake_groups[key] + "]"
-
-# LIGHT COMMANDS
+  # LIGHT COMMANDS
   robot.respond /hue lights/i, (msg) ->
-    light = msg.match[1]
-    url = "http://#{base_url}/api/#{hash}/lights"
-    getGenInfo msg, url, (responseText) ->
-      msg.send responseText
+    api.lights (err, lights) ->
+      return handleError msg, err if err
+      robot.logger.debug lights
+      msg.send "Connected hue lights:"
+      for light in lights.lights
+        msg.send "- #{light.id}: '#{light.name}'"
 
   robot.respond /hue light (.*)/i, (msg) ->
     light = msg.match[1]
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}"
-    getGenInfo msg, url, (responseText) ->
-      msg.send responseText
+    api.lightStatus light, (err, light) ->
+      return handleError msg, err if err
+      robot.logger.debug light
+      msg.send "Light Status:"
+      msg.send "- On: #{light.state.on}"
+      msg.send "- Reachable: #{light.state.reachable}"
+      msg.send "- Name: '#{light.name}'"
+      msg.send "- Model: #{light.modelid} - #{light.type}"
+      msg.send "- Unique ID: #{light.uniqueid}"
+      msg.send "- Software Version: #{light.swversion}"
 
-  robot.respond /hue @(\w+) hsb=\((\d+),(\d+),(\d+)\)/i, (msg) ->
-    [group_name,hue,sat,bri] = msg.match[1..4]
-    jsonParams =
-      hue: parseInt(hue)
-      sat: parseInt(sat)
-      bri: parseInt(bri)
-    fake_groups[group_name].forEach (light) ->
-      url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-      setInfo msg, url, jsonParams, (responseText) ->
-        msg.send "okay. set the following lights: " + fake_groups[group_name]
+  robot.respond /hue @(\d+) hsb=\((\d+),(\d+),(\d+)\)/i, (msg) ->
+    [group, vHue, vSat, vBri] = msg.match[1..4]
+    msg.send "Setting light group #{group} to: Hue=#{vHue}, Saturation=#{vSat}, Brightness=#{vBri}"
+    state = lightState.create().on(true).bri(vBri).hue(vHue).sat(vSat)
+    api.setGroupLightState group, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
-  robot.respond /hue hsb light (.*) (\d+) (\d+) (\d+)/i, (msg) ->
-    [light,hue,sat,bri] = msg.match[1..4]
-    jsonParams =
-      hue: parseInt(hue)
-      sat: parseInt(sat)
-      bri: parseInt(bri)
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-    setInfo msg, url, jsonParams, (responseText) ->
-      msg.send responseText
+  robot.respond /hue hsb light (\d+) (\d+) (\d+) (\d+)/i, (msg) ->
+    [light, vHue, vSat, vBri] = msg.match[1..4]
+    msg.send "Setting light #{light} to: Hue=#{vHue}, Saturation=#{vSat}, Brightness=#{vBri}"
+    state = lightState.create().on(true).bri(vBri).hue(vHue).sat(vSat)
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
-  robot.respond /hue @(\w+) xy=\(([0-9]*[.][0-9]+),([0-9]*[.][0-9]+)\)/i, (msg) ->
-    [group_name,x_str,y_str] = msg.match[1..3]
-    x = parseFloat(x_str)
-    y = parseFloat(y_str)
-    jsonParams =
-      xy: [x,y]
-    fake_groups[group_name].forEach (light) ->
-      url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-      setInfo msg, url, jsonParams, (responseText) ->
-        msg.send "okay. set the following lights: " + fake_groups[group_name]
+  robot.respond /hue @(\d+) xy=\(([0-9]*[.][0-9]+),([0-9]*[.][0-9]+)\)/i, (msg) ->
+    [group_name,x,y] = msg.match[1..3]
+    groupMap group_name, (group) ->
+      return msg.send "Could not find '#{group_name}' in list of groups" unless group
+      msg.send "Setting light group #{group} to: X=#{x}, Y=#{y}"
+      state = lightState.create().on(true).xy(x, y)
+      api.setGroupLightState group, state, (err, status) ->
+        return handleError msg, err if err
+        robot.logger.debug status
 
   robot.respond /hue xy light (.*) ([0-9]*[.][0-9]+) ([0-9]*[.][0-9]+)/i, (msg) ->
-    [light,x_str,y_str] = msg.match[1..3]
-    x = parseFloat(x_str)
-    y = parseFloat(y_str)
-    jsonParams =
-       xy: [x,y]
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-    setInfo msg, url, jsonParams, (responseText) ->
-      msg.send responseText
+    [light,x,y] = msg.match[1..3]
+    msg.send "Setting light #{light} to: X=#{x}, Y=#{y}"
+    state = lightState.create().on(true).xy(x, y)
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
-  robot.respond /hue @(\w+) ct=(\d\d\d)/i, (msg) ->
-    [group_name,color_temp] = msg.match[1..2]
-    jsonParams =
-      ct: parseInt(color_temp)
-    fake_groups[group_name].forEach (light) ->
-      url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-      setInfo msg, url, jsonParams, (responseText) ->
-        msg.send "okay. set the following lights: " + fake_groups[group_name]
+  robot.respond /hue @(\w+) ct=(\d{3})/i, (msg) ->
+    [group_name,ct] = msg.match[1..2]
+    groupMap group_name, (group) ->
+      return msg.send "Could not find '#{group_name}' in list of groups" unless group
+      msg.send "Setting light group #{group} to: CT=#{ct}"
+      state = lightState.create().on(true).ct(ct)
+      api.setGroupLightState group, state, (err, status) ->
+        return handleError msg, err if err
+        robot.logger.debug status
 
-  robot.respond /hue ct light (.*) (\d\d\d)/i, (msg) ->
-    [light,color_temp] = msg.match[1..2]
-    jsonParams =
-       ct: parseInt(color_temp)
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-    setInfo msg, url, jsonParams, (responseText) ->
-      msg.send responseText
+  robot.respond /hue ct light (.*) (\d{3})/i, (msg) ->
+    [light,ct] = msg.match[1..2]
+    msg.send "Setting light #{light} to: CT=#{ct}"
+    state = lightState.create().on(true).ct(ct)
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
   robot.respond /hue @(\w+) (on|off)/i, (msg) ->
     [group_name, state] = msg.match[1..2]
-    jsonParams =
-      on: if state is "on" then true else false
-    fake_groups[group_name].forEach (light) ->
-      url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-      setInfo msg, url, jsonParams, (responseText) ->
-        msg.send "okay. set the following lights: " + fake_groups[group_name]
+    groupMap group_name, (group) ->
+      return msg.send "Could not find '#{group_name}' in list of groups" unless group
+      msg.send "Setting light group #{group} to #{state}"
+      state = lightState.create().on(state=='on')
+      api.setGroupLightState group, state, (err, status) ->
+        return handleError msg, err if err
+        robot.logger.debug status
 
-  robot.respond /hue turn light (.+) (.+)/i, (msg) ->
+  robot.respond /hue turn light (\d+) (on|off)/i, (msg) ->
     [light, state] = msg.match[1..2]
-    msg.send "get off your LAZY ass and turn it " + state + " yourself"
-    jsonParams =
-       on: if state is "on" then true else false
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-    setInfo msg, url, jsonParams, (responseText) ->
-      msg.send responseText
+    msg.send "Setting light #{light} to #{state}"
+    state = lightState.create().on(state=='on')
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
   robot.respond /hue (alert|alerts) light (.+)/i, (msg) ->
-    [state,light] = msg.match[1..2]
-    msg.send "ain't nobody got time for that!"
+    [alert_length,light] = msg.match[1..2]
+    if alert_length == 'alert'
+      alert_text = 'short alert'
+      state = lightState.create().alertShort()
+    else
+      alert_text = 'long alert'
+      state = lightState.create().alertLong()
+    msg.send "Setting light #{light} to #{alert_text}"
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
 
-    jsonParams = alert: if state is "alert" then "select" else "lselect"
-
-    url = "http://#{base_url}/api/#{hash}/lights/#{light}/state"
-    setInfo msg, url, jsonParams, (responseText) ->
-      msg.send responseText
-
-
-# BRIDGE COMMANDS
+  # BRIDGE COMMANDS
   robot.respond /hue config/i, (msg) ->
-    url = "http://#{base_url}/api/#{hash}/config"
-    getGenInfo msg, url, (responseText) ->
-      msg.send "Config: " + responseText
+    api.config (err, config) ->
+      return handleError msg, err if err
+      robot.logger.debug config
+      msg.send "Base Station: '#{config.name}'"
+      msg.send "IP: #{config.ipaddress} / MAC: #{config.mac} / ZigBee Channel: #{config.zigbeechannel}"
+      msg.send "Software: #{config.swversion} / API: #{config.apiversion} / Update Available: #{config.swupdate.updatestate}"
 
   robot.respond /hue hash/i, (msg) ->
     msg.http("http://#{base_url}/api")
@@ -202,40 +218,25 @@ module.exports = (robot) ->
             if (line.success)
               msg.send "Hash:" + line.success.username
 
-  robot.respond /hue set config ([^\s]*) (.*)/i, (msg) ->
-    [setting,val] = msg.match[1..2]
-    supportedSettings = ['name','linkbutton']
-    if setting in supportedSettings
+  robot.respond /hue (link|linkbutton|link button)/i, (msg) ->
+    api.pressLinkButton (err, status) ->
+      return handleError msg, err if err
+      msg.send "Link button pressed!"
 
-      switch setting
-        when "name" then jsonParams = name: val
-        when "linkbutton" then jsonParams = linkbutton: val
+  # HELPERS
+  groupMap = (group_name, callback) ->
+    robot.logger.debug "mapping group names to group ids"
+    api.groups (err, groups) ->
+      return handleError msg, err if err
+      group_map = {}
+      for group in groups
+        robot.logger.debug group
+        if group.id == '0'
+          group_map['all'] = '0'
+        else
+          group_map[group.name.toLowerCase()] = group.id
+      match = group_map[group_name.toLowerCase()]
+      callback match
 
-      msg.send JSON.stringify(jsonParams)
-      url = "http://#{base_url}/api/#{hash}/config"
-      setInfo msg, url, jsonParams, (responseText) ->
-        msg.send responseText
-    else
-      msg.send "unsupported config setting"
-
-
-#  robot.respond /rollout activate_user ([^\s]*) ([^\s]*)/i, (msg) ->
-#    msg.http(endpoint + msg.match[1] + '/users').query(user: msg.match[2]).put() (err, res, body) ->
-#      show(msg, msg.match[1])
-
-getGenInfo = (msg, url, callback) ->
-    msg.http(url)
-      .headers(Accept: 'application/json')
-      .get() (err, res, body) ->
-         if 200 <= res.statusCode <= 299
-           callback JSON.stringify(JSON.parse(body),null,'\t')
-         else
-           callback res.statusCode
-
-setInfo = (msg, url, jsonParams, callback) ->
-    msg.http(url)
-      .put(JSON.stringify(jsonParams)) (err, res, body) ->
-            if 200 <= res.statusCode <= 299
-              callback JSON.stringify(JSON.parse(body),null,'\t')
-            else
-              callback res.statusCode
+  handleError = (msg, err) ->
+    msg.send err

--- a/test/philipshue_test.coffee
+++ b/test/philipshue_test.coffee
@@ -11,5 +11,37 @@ describe 'philips-hue', ->
 
     require('../src/philips-hue')(@robot)
 
-  it 'registers a respond listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/hue lights/)
+  it 'registers a groups listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue (?:ls )?groups/i)
+  it 'registers a group add listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue group (\w+)=(\[((\d)+,)*((\d)+)\])/i)
+  it 'registers a group remove listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue rm group (\d)/i)
+  it 'registers a lights listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue lights/i)
+  it 'registers a light listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue light (.*)/i)
+  it 'registers a group HSB listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue @(\d+) hsb=\((\d+),(\d+),(\d+)\)/i)
+  it 'registers a light HSB listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue hsb light (\d+) (\d+) (\d+) (\d+)/i)
+  it 'registers a group XY listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue @(\d+) xy=\(([0-9]*[.][0-9]+),([0-9]*[.][0-9]+)\)/i)
+  it 'registers a light XY listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue xy light (.*) ([0-9]*[.][0-9]+) ([0-9]*[.][0-9]+)/i)
+  it 'registers a group color temperature listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue @(\w+) ct=(\d{3})/i)
+  it 'registers a light color temperature listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue ct light (.*) (\d{3})/i)
+  it 'registers a group switch listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue @(\w+) (on|off)/i)
+  it 'registers a light switch listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue turn light (\d+) (on|off)/i)
+  it 'registers a light alert listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue (alert|alerts) light (.+)/i)
+  it 'registers a config listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue config/i)
+  it 'registers a hash listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue hash/i)
+  it 'registers a link button listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue (link|linkbutton|link button)/i)


### PR DESCRIPTION
- Refactors to use [`node-hue-api`](https://github.com/peter-murray/node-hue-api) package for simplified calls
- Adds light groups to the bridge (rather than use an in-memory hash)
- Adds test coverage to all registered listeners
- Improves output from scripts to no longer spit out raw JSON
- Makes it slightly more polite :grin:

Tested with Slack adapter and a hue starter kit.

Fixes #1 by virtue of reducing backtalk to meaningful stuff.

---

Edit 1: Adds group note above
