### PR TITLE
Fix Travis-CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a hubot plugin that will control your philips hue lights
 
-[![Build Status](https://travis-ci.org/hubot-scripts/hubot-example.png)](https://travis-ci.org/kingbin/hubot-philipshue)
+[![Build Status](https://travis-ci.org/kingbin/hubot-philipshue.png)](https://travis-ci.org/kingbin/hubot-philipshue)
 
 ## Dependencies:
 - [A Local Hubot Installation](https://github.com/github/hubot/blob/master/docs/README.md "A Local Hubot Installation")


### PR DESCRIPTION
The example badge that was previously linked was inaccurate. The link attached to the badge was correct. Trivial change, probably not worth a version bump.