### PR TITLE
Add a commands to allow the `colorloop` effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ $ curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d
 -   hubot hue hash - get a hash code (press the link button)
 -   hubot hue linkbutton - programatically press the link button
 -   hubot hue {alert|alerts} light {light number} - blink once or blink for 10 seconds specific light
+-   hubot hue {colors|colorloop|loop} {on|off} light {light number} - enable or disable the colorloop effect
 -   hubot hue group {group name}=[{comma separated list of light indexes}]
 -   hubot hue ls groups - lists the groups of lights
 -   hubot hue rm group {group name} - remove grouping of lights named <group name>

--- a/src/philips-hue.coffee
+++ b/src/philips-hue.coffee
@@ -37,6 +37,7 @@
 #   hubot hue hash - get a hash code (press the link button)
 #   hubot hue linkbutton - programatically press the link button
 #   hubot hue (alert|alerts) light <light number> - blink once or blink for 10 seconds specific light
+#   hubot hue (colors|colorloop|colorloop) (on|off) light <light number> - enable or disable the colorloop effect
 #   hubot hue hsb light <light number> <hue 0-65535> <saturation 0-254> <brightness 0-254>
 #   hubot hue xy light <light number> <x 0.0-1.0> <y 0.0-1.0>
 #   hubot hue ct light <light number> <color temp 153-500>
@@ -194,6 +195,19 @@ module.exports = (robot) ->
       alert_text = 'long alert'
       state = lightState.create().alertLong()
     msg.send "Setting light #{light} to #{alert_text}"
+    api.setLightState light, state, (err, status) ->
+      return handleError msg, err if err
+      robot.logger.debug status
+
+  robot.respond /hue (?:colors|colorloop|loop) (on|off) light (.+)/i, (msg) ->
+    [loop_status,light] = msg.match[1..2]
+    if loop_status == 'on'
+      colorloop_text = 'on'
+      state = lightState.create().effect('colorloop')
+    else
+      colorloop_text = 'off'
+      state = lightState.create().effect('none')
+    msg.send "Setting light #{light} colorloop to #{colorloop_text}"
     api.setLightState light, state, (err, status) ->
       return handleError msg, err if err
       robot.logger.debug status

--- a/test/philipshue_test.coffee
+++ b/test/philipshue_test.coffee
@@ -39,6 +39,8 @@ describe 'philips-hue', ->
     expect(@robot.respond).to.have.been.calledWith(/hue turn light (\d+) (on|off)/i)
   it 'registers a light alert listener', ->
     expect(@robot.respond).to.have.been.calledWith(/hue (alert|alerts) light (.+)/i)
+  it 'registers a colorloop listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/hue (?:colors|colorloop|loop) (on|off) light (.+)/i)
   it 'registers a config listener', ->
     expect(@robot.respond).to.have.been.calledWith(/hue config/i)
   it 'registers a hash listener', ->


### PR DESCRIPTION
The API has a feature that allows the hub to send a sequence of colors (with transitions) to the bulbs that support it. This PR allows a user to invoke this effect on or off for a particular light.

```
User> hubot hue colorloop on light 1
Hubot> Setting light 1 colorloop to on

[..]

User> hubot hue colorloop off light 1
Hubot> Setting light 1 colorloop to off
```