### PR TITLE
Update package-lock.json on Grunt release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function (grunt) {
     release: {
       options: {
         tagName: 'v<%= version %>',
-        commitMessage: 'Prepared to release <%= version %>.'
+        commitMessage: 'Prepared to release <%= version %>.',
+        additionalFiles: ['package-lock.json']
       }
     },
     watch: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-philipshue",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The `package-lock.json` version file was not being updated when the package was released via the automated Grunt script. This adds it to the `additionalFiles` directive which will find the `version` property and match it with the one in `package.json`.

Usage:

```
$ grunt release:<major|minor|patch>
```